### PR TITLE
Fix collison algorithm

### DIFF
--- a/solver/namachan/src/basic_data.d
+++ b/solver/namachan/src/basic_data.d
@@ -32,6 +32,9 @@ public:
 		else static if (op == "*") {
 			return x*p.x+y*p.y;
 		}
+		else static if (op == "%") {
+			return Vector!T (x%p.x, y%p.y);
+		}
 	}
 
 	@safe @nogc
@@ -48,6 +51,9 @@ public:
 		else static if (op == "/") {
 			return Vector!T (x/n, y/n);
 		}
+		else static if (op == "%") {
+			return Vector!T (x%n, y%n);
+		}
 	}
 
 	@safe @nogc
@@ -59,6 +65,10 @@ public:
 		else static if (op == "-") {
 			x -= p.x;
 			y -= p.y;
+		}
+		else static if (op == "%") {
+			x %= p.x;
+			y %= p.y;
 		}
 	}
 
@@ -79,6 +89,10 @@ public:
 		else static if (op == "/") {
 			x /= n;
 			y /= n;
+		}
+		else static if (op == "%") {
+			x %= n;
+			y %= n;
 		}
 	}
 
@@ -114,6 +128,9 @@ unittest {
 	assert (cast(Vector!float)(v1) == Vector!float(107.0f, -122.0f));
 	//Vector!T型以外へのキャストは不可能
 	static assert (!__traits(compiles, cast(float)v1));
+
+	assert (v1 % 3 == Vector!int(2, -2));
+	assert (v1 % Vector!int(3, 7) == Vector!int(2, -3));
 }
 
 alias Pos = Vector!int;

--- a/solver/namachan/src/basic_data.d
+++ b/solver/namachan/src/basic_data.d
@@ -102,6 +102,18 @@ public:
 	pure nothrow T norm2() const {
 		return x^^2+y^^2;
 	}
+
+	@safe @nogc
+	pure nothrow Vector!T2 opCast(V : Vector!T2, T2) () const {
+		return Vector!T2 (cast(T2)x, cast(T2)y);
+	}
+}
+unittest {
+	auto v1 = Vector!int (107, -122);
+	//キャスト
+	assert (cast(Vector!float)(v1) == Vector!float(107.0f, -122.0f));
+	//Vector!T型以外へのキャストは不可能
+	static assert (!__traits(compiles, cast(float)v1));
 }
 
 alias Pos = Vector!int;

--- a/solver/namachan/src/solver/datamanip.d
+++ b/solver/namachan/src/solver/datamanip.d
@@ -330,10 +330,26 @@ nothrow pure bool protrude_frame (in P[] frame,in P[] shape) {
 		}
 		pos_sum += shape[p_idx];
 	}
-	import std.conv : to;
-	immutable gravity_point = pos_sum / cast(int)shape.length;
-	if (crossing_number(gravity_point, shape) && !crossing_number(gravity_point, frame))
-		return true;
+	for (int p_idx1; p_idx1 < shape.length; ++p_idx1) {
+		immutable p_idx2 = (p_idx1 + 1) % shape.length;
+		immutable point_sum = shape[p_idx1] + shape[p_idx2];
+		immutable int x1 = point_sum.x / 2;
+		immutable int x2 = (point_sum.x + 1) / 2;
+		immutable int y1 = point_sum.y / 2;
+		immutable int y2 = (point_sum.y + 1) / 2;
+		immutable P[4] ps = [
+			P(x1, y1),
+			P(x2, y1),
+			P(x1, y2),
+			P(x2, y2)
+		];
+		bool all_protruded = true;
+		foreach (p; ps)
+			if (crossing_number(p, frame))
+				all_protruded = false;
+		if (all_protruded)
+			return true;
+	}
 	return false;
 }
 unittest {

--- a/solver/namachan/src/solver/datamanip.d
+++ b/solver/namachan/src/solver/datamanip.d
@@ -312,6 +312,11 @@ nothrow pure bool judge_on_line (in Pos p, in P start, in P end) {
 
 @safe @nogc
 nothrow pure bool protrude_frame (in P[] frame,in P[] shape) {
+	import std.conv : to;
+	P pos_sum;
+	immutable gravity_point = pos_sum / cast(int)shape.length;
+	if (crossing_number(gravity_point, shape) && !crossing_number(gravity_point, frame))
+		return true;
 	foreach (shape_vertex; shape) {
 		if (!crossing_number(shape_vertex, frame))
 			return true;
@@ -320,7 +325,6 @@ nothrow pure bool protrude_frame (in P[] frame,in P[] shape) {
 		if (crossing_number(frame_vertex, shape, false))
 			return true;
 	}
-	P pos_sum;
 	for (int p_idx; p_idx < shape.length; ++p_idx) {
 		for (int f_idx; f_idx < frame.length; ++f_idx) {
 			if (judge_intersected (


### PR DESCRIPTION
中点がフレームの内部にあるか判定することはやはり必要だったが、何も考えず中点を求めると除算誤差で線分上に無い点を中点としてしまう。除算誤差を考慮してx,yそれぞれ丸め方向を変えて4点を調べ、全てがフレーム外ならフレームからはみ出していると判定する。この方法にはコーナーケースが存在し、真の中点とフレームの距離が1未満であった場合ははみ出していないとされてしまう。ただこの条件になる組み合わせを作れるピースはかなり小さい突起を持つ必要があるため現実ではあまり発生するとは思えない。